### PR TITLE
Update Fedora package version.

### DIFF
--- a/site/download.htm
+++ b/site/download.htm
@@ -123,11 +123,12 @@ sudo apt-get install crawl
 # install tiles version
 sudo apt-get install crawl-tiles</pre>
                     </ul>
-                    <h4>Fedora 22/21</h4>
-                    <p>BlasterBlade provides Fedora packages for Crawl (0.17.0 tiles and console builds) in the openSUSE Build System repository. To install the tiles version, run the following:</p>
+                    <h4>Fedora 23/22/21</h4>
+                    <p>BlasterBlade provides Fedora packages for Crawl in the openSUSE Build System repository. To install the tiles version, run the following:</p>
                     <pre>cd /etc/yum.repos.d/
 # Install the source repository
 sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_23/home:nazar554.repo
+# Replace dnf with yum for Fedora 22/21
 # install tiles version
 sudo dnf install crawl-sdl crawl-data
 # install console version

--- a/site/download.htm
+++ b/site/download.htm
@@ -124,14 +124,14 @@ sudo apt-get install crawl
 sudo apt-get install crawl-tiles</pre>
                     </ul>
                     <h4>Fedora 22/21</h4>
-                    <p>BlasterBlade provides Fedora packages for Crawl (0.16.2 tiles and console builds) in the openSUSE Build System repository. To install the tiles version, run the following (for Fedora 21, replace the 22 in the URL):</p>
+                    <p>BlasterBlade provides Fedora packages for Crawl (0.17.0 tiles and console builds) in the openSUSE Build System repository. To install the tiles version, run the following:</p>
                     <pre>cd /etc/yum.repos.d/
 # Install the source repository
-sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_22/home:nazar554.repo
+sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_23/home:nazar554.repo
 # install tiles version
-sudo yum install crawl-sdl crawl-data
+sudo dnf install crawl-sdl crawl-data
 # install console version
-sudo yum install crawl-console crawl-data</pre>
+sudo dnf install crawl-console crawl-data</pre>
 
                     <a name="source"></a>
                     <h3>Source Code</h3>


### PR DESCRIPTION
Fedora < 23 0.17.0 builds are broken due to missing perl-Unicode-Collate (required
by columnise-credits.pl). Should I add download instructions for
previous Fedora versions (0.16.2)? Or is there a workaround?
