### PR TITLE
Removed EOL Fedora versions & package updated to 0.19.4

### DIFF
--- a/site/download.htm
+++ b/site/download.htm
@@ -133,16 +133,15 @@ sudo apt-get update
 sudo apt-get install crawl
 # install tiles version
 sudo apt-get install crawl-tiles</pre>
-                        <h4>Fedora 24/23/22/21</h4>
+                        <h4>Fedora 25/24</h4>
                         <p>
-                            BlasterBlade provides Fedora packages for Crawl in
+                            nazar554 provides Fedora packages for Crawl in
                             the openSUSE Build System repository. To install
                             the tiles version, run the following:
                         </p>
                         <pre>cd /etc/yum.repos.d/
 # Install the source repository
-sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_24/home:nazar554.repo
-# Replace dnf with yum for Fedora 22/21
+sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_25/home:nazar554.repo
 # install tiles version
 sudo dnf install crawl-sdl crawl-data
 # install console version


### PR DESCRIPTION
Fedora versions 21-23 have long passed EOL, OBS soon won't support them
https://fedoraproject.org/wiki/End_of_life