### PR TITLE
Fix broken link to Source Code INSTALL file.

### DIFF
--- a/site/download.htm
+++ b/site/download.htm
@@ -154,7 +154,7 @@ sudo dnf install crawl-console crawl-data</pre>
                             repository on github</a>. For help using git, see
                             the <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/docs/develop/git/quickstart.txt">quickstart
                             guide</a>. For help compiling DCSS,
-                            see <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/INSTALL.txt">INSTALL.txt</a>.
+                            see <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/INSTALL.md">INSTALL.md</a>.
                         </p>
                 </div>
             </div>


### PR DESCRIPTION
When this documentation got converted to Markdown, the filename changed.