### PR TITLE
Change Install instructions for Fedora

### DIFF
--- a/site/download.htm
+++ b/site/download.htm
@@ -133,19 +133,14 @@ sudo apt-get update
 sudo apt-get install crawl
 # install tiles version
 sudo apt-get install crawl-tiles</pre>
-                        <h4>Fedora 25/24</h4>
+                        <h4>Fedora 31/32</h4>
                         <p>
-                            nazar554 provides Fedora packages for Crawl in
-                            the openSUSE Build System repository. To install
-                            the tiles version, run the following:
+                            Fedora updates repository contains recent version of DCSS packages.
                         </p>
-                        <pre>cd /etc/yum.repos.d/
-# Install the source repository
-sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_25/home:nazar554.repo
+                        <pre># Install console version
+sudo dnf install crawl
 # install tiles version
-sudo dnf install crawl-sdl crawl-data
-# install console version
-sudo dnf install crawl-console crawl-data</pre>
+sudo dnf install crawl-tiles
                         <a name="source"></a>
                         <h3>Source Code</h3>
                         <p>


### PR DESCRIPTION
nazar554 no longers provide custom DCCS packages. But the Fedora official repository contains a somewhat updated version for the last few years.