### PR TITLE
Update the downloads page

### DIFF
--- a/site/download.htm
+++ b/site/download.htm
@@ -10,6 +10,7 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.2/js/bootstrap.min.js"></script>
     </head>
+
     <body>
         <div class="container">
             <div class="page-header">
@@ -22,7 +23,9 @@
                 <div class="col-md-offset-2 col-md-8 col-sm-12">
 
                     <h2 class="text-center">Download</h2>
-		    <h5 class="text-center">Latest Stable Version: <a href="https://github.com/crawl/crawl/releases/tag/0.29.1"><strong>0.29.1</strong></a>
+                    <h5 class="text-center">
+                        Latest Stable Version: <a href="https://github.com/crawl/crawl/releases/tag/0.29.1"><strong>0.29.1</strong></a>
+                    </h5>
                     <table class="table" style="text-align: center;">
                         <thead>
                             <tr>
@@ -37,88 +40,131 @@
                                 </th>
                             </tr>
                         </thead>
+
                         <tbody>
                             <tr>
                                 <th scope="row">Windows Installer</th>
                                 <td colspan=2>
-                                  <ul class="list-unstyled">
-                                    <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-win32-installer.exe">Download Tiles+Console</a></li>
-                                  </ul>
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-win32-installer.exe">Download Tiles+Console</a></li>
+                                    </ul>
                                 <td>
                             </tr>
+
                             <tr>
                                 <th scope="row">Windows Zips</th>
                                 <td>
-                                  <ul class="list-unstyled">
-                                    <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-win32-tiles.zip">Download</a></li>
-                                  </ul>
-                                </td>
-                                <td>
-                                  <ul class="list-unstyled">
-                                    <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-win32-console.zip">Download</a></li>
-                                  </ul>
-                                </td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Mac OS X</th>
-                                <td><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-macos-tiles-universal.zip">Download</a></td>
-                                <td><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-macos-console-universal.zip">Download</a></td>
-                            </tr>
-                            <tr>
-                                <th scope="row">Android</th>
-                                <td>
                                     <ul class="list-unstyled">
-                                    <li>Current version, maintained by robertxgray/Medrano83:</li>
-                                    <li><a href="https://play.google.com/store/apps/details?id=org.develz.crawl">
-                                        <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="210px" height="80px">
-                                    </a></li>
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-win32-tiles.zip">Download</a></li>
                                     </ul>
                                 </td>
-                                <td></td>
+                                <td>
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-win32-console.zip">Download</a></li>
+                                    </ul>
+                                </td>
                             </tr>
+
                             <tr>
-                              <th scope="row">Linux</th>
-                              <td colspan="2"><a href="#linux">See Instructions</a></td>
+                                <th scope="row">Mac OS X</th>
+                                <td>
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-macos-tiles-universal.zip">Download</a></li>
+                                    </ul>
+                                </td>
+                                <td>
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-macos-console-universal.zip">Download</a></li>
+                                    </ul>
+                                </td>
                             </tr>
+
                             <tr>
-                              <th scope="row">Source</th>
-                              <td colspan="2">
-                                <ul class="list-unstyled">
-                                  <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/stone_soup-0.29.1.zip">Full source</a></li>
-                                  <li><a href="https://github.com/crawl/crawl/releases/tag/0.29.1">Other formats</a></li>
-                                  <li><a href="#source">See Git Instructions Below</a></li>
-                                </ul>
-                              </td>
+                                <th scope="row">Linux AppImages</th>
+                                <td>
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-linux-tiles.x86_64.AppImage">Download</a></li>
+                                    </ul>
+                                </td>
+                                <td>
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/dcss-0.29.1-linux-console.x86_64.AppImage">Download</a></li>
+                                    </ul>
+                                </td>
                             </tr>
+
                             <tr>
-                              <th scope="row">Past Releases</th>
-                                <td colspan="2"><a href="release/?C=N;O=D">Releases Folder</a></td>
-                              </td>
+                                <th scope="row">Linux Packages</th>
+                                <td colspan="2">
+                                    <ul class="list-unstyled">
+                                        <li><a href="#linux">See Instructions</a></li>
+                                    </ul>
+                                </td>
                             </tr>
+
                             <tr>
-                              <th scope="row">Development Builds</th>
-                                <td colspan="2"><a href="trunk/">Trunk Builds Page</a></td>
-                              </td>
+                                <th scope="row"><p>Android</p><p style="font-weight: normal;">Published by Medrano83</p></th>
+                                <td>
+                                    <a href="https://play.google.com/store/apps/details?id=org.develz.crawl">
+                                        <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="210px" height="80px">
+                                    </a>
+                                </td>
+                                <td>
+                                    <a href="https://f-droid.org/es/packages/org.develz.crawl/">
+                                        <img alt="Get it on F-Droid" src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" width="210px" height="80px">
+                                    </a>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <th scope="row">Source</th>
+                                <td colspan="2">
+                                    <ul class="list-unstyled">
+                                        <li><a href="https://github.com/crawl/crawl/releases/download/0.29.1/stone_soup-0.29.1.zip">Full source</a></li>
+                                        <li><a href="https://github.com/crawl/crawl/releases/tag/0.29.1">Other formats</a></li>
+                                        <li><a href="#source">See Git Instructions Below</a></li>
+                                    </ul>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <th scope="row">Past Releases</th>
+                                <td colspan="2">
+                                    <ul class="list-unstyled">
+                                        <li><a href="release/?C=N;O=D">Releases Folder</a></li>
+                                    </ul>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <th scope="row">Development Builds</th>
+                                <td colspan="2">
+                                    <ul class="list-unstyled">
+                                        <li><a href="trunk/">Trunk Builds Page</a></li>
+                                    </ul>
+                                </td>
                             </tr>
                         </tbody>
                     </table>
 
                     <a name="linux"></a>
                     <h3>Linux</h3>
-                        <p>
-                            A version of DCSS may be available in your
-                            distribution's main package repository; look for
-                            the packages 'crawl' and/or 'crawl-tiles'. These
-                            packages tend to be for versions older than the
-                            current stable release, so use the packages below
-                            if you can.
-                        </p>
-                        <h4>Ubuntu, Debian &amp; other Debian derivatives</h4>
-                        <p>
-                            DCSS packages are available for i386, amd64 and
-                            armel architectures. Follow these instructions:
-                        </p>
-                        <pre># Install the source repository
+                    <p>
+                        A version of DCSS may be available in your distribution's main package repository; look
+                        for the packages 'crawl' (for the console version) and 'crawl-tiles' or 'crawl-sdl' (for
+                        the tiles version). These packages tend to be for versions older than the current stable
+                        release, so use the packages below if you can.
+                    </p>
+                    <p>
+                        Unofficial builds of the tiles version are also available at
+                        <a href="https://flathub.org/apps/details/org.develz.Crawl">Flathub</a> and
+                        <a href="https://snapcraft.io/dungeon-crawl">Snapcraft</a>.
+                    </p>
+                    <h4>Ubuntu, Debian &amp; other Debian derivatives</h4>
+                    <p>
+                        DCSS packages are available for i386 and amd64 architectures. Follow these instructions:
+                    </p>
+<pre># Install the source repository
 echo 'deb https://crawl.develz.org/debian crawl 0.29' | sudo tee -a /etc/apt/sources.list
 # Install the DCSS signing key
 wget https://crawl.develz.org/debian/pubkey -O - | sudo apt-key add -
@@ -128,32 +174,18 @@ sudo apt-get update
 sudo apt-get install crawl
 # install tiles version
 sudo apt-get install crawl-tiles</pre>
-                        <h4>Fedora 25/24</h4>
-                        <p>
-                            nazar554 provides Fedora packages for Crawl in
-                            the openSUSE Build System repository. To install
-                            the tiles version, run the following:
-                        </p>
-                        <pre>cd /etc/yum.repos.d/
-# Install the source repository
-sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_25/home:nazar554.repo
-# install tiles version
-sudo dnf install crawl-sdl crawl-data
-# install console version
-sudo dnf install crawl-console crawl-data</pre>
-                        <a name="source"></a>
-                        <h3>Source Code</h3>
-                        <p>
-                            To compile DCSS yourself, you can clone
-                            the <a href="https://github.com/crawl/crawl">git
-                            repository on github</a>. For help using git, see
-                            the <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/docs/develop/git/quickstart.txt">quickstart
-                            guide</a>. For help compiling DCSS,
-                            see <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/INSTALL.md">INSTALL.md</a>.
-                        </p>
+                    <h3>Source Code</h3>
+                    <p>
+                        To compile DCSS yourself, you can clone the
+                        <a href="https://github.com/crawl/crawl">git repository on github</a>.
+                        For help using git, see the
+                        <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/docs/develop/git/quickstart.txt">quickstart guide</a>.
+                        For help compiling DCSS, see
+                        <a href="https://github.com/crawl/crawl/blob/master/crawl-ref/INSTALL.md">INSTALL.md</a>.
+                    </p>
                 </div>
             </div>
-            <hr>
+            <hr/>
             <p class="small text-right">You are too berserk!</p>
         </div>
     </body>


### PR DESCRIPTION
- Add: Linux AppImages.
- Add: F-Droid repository.
- Add: References to Flathub and Snapcraft.
- Add: Reference to crawl-sdl packages.
- Remove: The Fedora repository no longer exists.
- Remove: Debian armel packages are no longer provided.
- Fix: Mixed height in table rows.
- Fix: Mixed indentation.
- Fix: Some tags are not closed.