### PR TITLE
Rework Ubuntu/Debian install instructions to not use apt-key

### DIFF
--- a/site/download.htm
+++ b/site/download.htm
@@ -165,9 +165,9 @@
                         DCSS packages are available for i386 and amd64 architectures. Follow these instructions:
                     </p>
 <pre># Install the source repository
-echo 'deb https://crawl.develz.org/debian crawl 0.33' | sudo tee -a /etc/apt/sources.list
+echo 'deb [signed-by=/usr/share/keyrings/crawl.gpg] https://crawl.develz.org/debian crawl 0.33' | sudo tee /etc/apt/sources.list.d/crawl.list
 # Install the DCSS signing key
-wget https://crawl.develz.org/debian/pubkey -O - | sudo apt-key add -
+wget -q https://crawl.develz.org/debian/pubkey -O - | gpg --dearmor | sudo tee /usr/share/keyrings/crawl.gpg > /dev/null
 # update your package list
 sudo apt-get update
 # install console version


### PR DESCRIPTION
Reworks the apt repository setup steps to stop using the deprecated `apt-key` when setting up the repository and it's signing key. Following the current instructions works but leaves users with the following warning from apt.

```
W: https://crawl.develz.org/debian/dists/crawl/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```

Also moves the crawl repo into it's own file (`/etc/apt/sources.list.d/crawl.list`) to keep `sources.list` cleaner. 